### PR TITLE
Melhorando abertura do arquivo edit-achievements no linux

### DIFF
--- a/dev-aberto.py
+++ b/dev-aberto.py
@@ -58,6 +58,8 @@ def edit_achievements(student_login):
 
     if 'win32' in sys.platform:
         editor = os.getenv('EDITOR', default='notepad.exe')
+    elif 'linux' in sys.platform:
+        editor = os.getenv('EDITOR', default='gnome-text-editor')
     else:
         editor = os.getenv('EDITOR', default='vi')
 

--- a/students/guilhermecl1
+++ b/students/guilhermecl1
@@ -1,0 +1,6 @@
+
+{
+    "login": "guilhermecl1",
+    "name": "Guilherme Carneiro Lunetta",
+    "ghuser": "guishas"
+}

--- a/students/guilhermecl1-achievements
+++ b/students/guilhermecl1-achievements
@@ -1,0 +1,1 @@
+gAAAAABi-6jndoLfCksxBHDvn-cHWtjrsFIiLQcCMUd5mK17L9CblhBway1XWxmmTDHDHdfKxEJZlDRJ-2mb626DMqctGUpglnIadAipHKrkdAkkozi4fSOkq4dWXeoq3z8xm4eFq7WOjd5CkuupaJHN2rt7yjozHw==


### PR DESCRIPTION
Antes, no Linux o editor Vi era aberto, agora, o editor de texto padrão do Linux é aberto. Eu testei no meu Linux e funcionou, é uma melhoria absurdamente simples e acredito que não vai dar problemas, ainda existe a condição "else" para casos de outros sistemas operacionais.